### PR TITLE
Fix for injecting code in projects which contain folders with spaces in them

### DIFF
--- a/InjectionPluginLite/injectSource.pl
+++ b/InjectionPluginLite/injectSource.pl
@@ -78,7 +78,7 @@ if ( ! -d $InjectionBundle ) {
     # you are injecting classes in frameworks.
     if ( my @includePath = loadFile( "find . -name '*.h' | sed -e 's!/[^/]*\$!!' | sort -u | grep -v InjectionProject |" ) ) {
         $bundleProjectSource =~ s!(HEADER_SEARCH_PATHS = \(\n)(\s+)"../\*\*",!
-            $1.join "\n", map "$2\".$_\",", @includePath;
+            $1.join "\n", map "$2\"\\\".$_\\\"\",", @includePath;
         !eg;
     }
 }


### PR DESCRIPTION
If you have a project whose files are organised in to folders (whose names have spaces in them), the single quotation marks will be removed by xcodebuild and you'll get missing header files.

Xcode itself requires you to wrap header paths with spaces in them in quotation marks, which it adds as another set of escaped quotation marks. e.g:

"\"../MyProj/MyProj/Some folder/Some sub folder\""
