### PR TITLE
post kINNotification in dispatch_get_main_queue()

### DIFF
--- a/InjectionPluginLite/Classes/BundleInjection.h
+++ b/InjectionPluginLite/Classes/BundleInjection.h
@@ -857,8 +857,10 @@ struct _in_objc_class { Class meta, supr; void *cache, *vtable; struct _in_objc_
         [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
 #endif
     status = referencesSection != NULL;
-    [[NSNotificationCenter defaultCenter] postNotificationName:kINNotification
+    dispatch_async(dispatch_get_main_queue(), ^{
+    	[[NSNotificationCenter defaultCenter] postNotificationName:kINNotification
                                                         object:nil];
+    });                                         
 }
 
 #endif


### PR DESCRIPTION
post kINNotification in dispatch_get_main_queue() in order to ensure it's not triggered before swizzling completed (it got out of order after swizzling has been moved to dispatch_get_main_queue block)
