### PR TITLE
Bug-Fix: Unhide doesn't report any warnings when build configuration is not Debug.

### DIFF
--- a/InjectionPluginLite/unhide/unhide.sh
+++ b/InjectionPluginLite/unhide/unhide.sh
@@ -6,6 +6,11 @@
 #  Created by John Holdsworth on 15/05/2015.
 #  Copyright (c) 2015 John Holdsworth. All rights reserved.
 #
+if [ "$CONFIGURATION" != "Debug" ]; then
+    echo "Your build configuration is $CONFIGURATION, and unhide.sh only can work with Debug build configuration"
+    echo "Please change your build configuration to Debug build configuration"
+    osascript -e 'display notification "unhide.sh only work with Debug build configuration" with title "Warning"'
+fi
 
 if [ "$CONFIGURATION" = "Debug" ]; then
     UNHIDE_LDFLAGS=${1:-$UNHIDE_LDFLAGS}

--- a/InjectionPluginLite/unhide/unhide.sh
+++ b/InjectionPluginLite/unhide/unhide.sh
@@ -8,8 +8,8 @@
 #
 if [ "$CONFIGURATION" != "Debug" ]; then
     echo "Your build configuration is $CONFIGURATION, and unhide.sh only can work with Debug build configuration"
-    echo "Please change your build configuration to Debug build configuration"
-    osascript -e 'display notification "unhide.sh only work with Debug build configuration" with title "Warning"'
+    echo "Please change your build configuration to Debug build configuration if it's necessary"
+    osascript -e 'display notification "unhide.sh only works with Debug build configuration" with title "Warning"'
 fi
 
 if [ "$CONFIGURATION" = "Debug" ]; then


### PR DESCRIPTION
I found this issue when a Xcode project's default build configuration was set to Release by someone. As a result, I got a crash after code injection because unhide.sh didn't work. The bug-fix will prompt user that he should use Debug build configuration if he wants to do code injection properly.