### PR TITLE
Do initialization in correct time

### DIFF
--- a/InjectionPluginLite/Classes/INPluginMenuController.m
+++ b/InjectionPluginLite/Classes/INPluginMenuController.m
@@ -86,9 +86,11 @@ static INPluginMenuController *injectionPlugin;
         dispatch_once( &onceToken, ^{
             injectionPlugin = [[self alloc] init];
             //NSLog( @"Preparing Injection: %@", injectionPlugin );
-            dispatch_async( dispatch_get_main_queue(), ^{
-                [injectionPlugin applicationDidFinishLaunching:nil];
-            } );
+            [[NSNotificationCenter defaultCenter]
+             addObserver:injectionPlugin
+             selector:@selector(applicationDidFinishLaunching:)
+             name:NSApplicationDidFinishLaunchingNotification
+             object:nil];
         } );
     }
 }


### PR DESCRIPTION
Every time I launch Xcode, it alerts "InInjectionPlugin: Could not locate Product Menu". Then I found an asynchronous but unreliable initialization was used. Maybe my Mac Mini is too slow and ever time it triggers above problem.
My solution is to do initialization when receiving notification of NSApplicationDidFinishLaunchingNotification.