### PR TITLE
Fixing build failure for folder name with '&' character in it.

### DIFF
--- a/InjectionPluginLite/injectSource.pl
+++ b/InjectionPluginLite/injectSource.pl
@@ -338,7 +338,7 @@ if ( $learnt ) {
         or die "Could not locate object file in: $learnt";
     ###$learnt =~ s/( -DDEBUG\S* )/$1-DINJECTION_BUNDLE /;
 
-    $learnt =~ s/([()])/\\$1/g;
+    $learnt =~ s/([()&])/\\$1/g;
     rtfEscape( my $lout = $learnt );
     print "Learnt compile: $compileHighlight $lout\n";
 


### PR DESCRIPTION
Learnt compile will fail if the source file is in a folder which name contains '&'.