### PR TITLE
Do not lock main GCD when executing tests

### DIFF
--- a/InjectionPluginLite/Classes/BundleInjection.h
+++ b/InjectionPluginLite/Classes/BundleInjection.h
@@ -231,6 +231,7 @@ static NSString *kPreviousInjections = @"INPreviousInjections";
 #ifndef ANDROID
 static NSNetServiceBrowser *browser;
 static NSNetService *service;
+static dispatch_queue_t testQueue;
 
 +(void)netServiceBrowser:(NSNetServiceBrowser *)aBrowser didFindService:(NSNetService *)aService moreComing:(BOOL)more {
     service = aService;
@@ -1092,7 +1093,8 @@ struct _in_objc_class { Class meta, supr; void *cache, *vtable; struct _in_objc_
     if ( referencesSection )
         dispatch_async(dispatch_get_main_queue(), ^{
             Class *classReferences = (Class *)(void *)((char *)info.dli_fbase+(uint64_t)referencesSection);
-
+            NSMutableArray *testClasses = [NSMutableArray array];
+            
             for ( unsigned long i=0 ; i<size/sizeof *classReferences ; i++ ) {
                 Class newClass = classReferences[i];
                 NSString *className = NSStringFromClass(newClass);
@@ -1110,15 +1112,33 @@ struct _in_objc_class { Class meta, supr; void *cache, *vtable; struct _in_objc_
                 }
 
                 if ( [newClass isSubclassOfClass:objc_getClass("XCTestCase")] ) {
-                    id suite0 = [[objc_getClass("XCTestSuite") alloc] initWithName:@"Injected"];
-                    id suite = [objc_getClass("XCTestSuite") testSuiteForTestCaseClass:newClass];
-                    id tr = [objc_getClass("XCTestSuiteRun") testRunWithTest:suite];
-                    [suite0 addTest:suite];
-                    [suite0 performTest:tr];
+                    [testClasses addObject:newClass];
                     if ( [newClass isSubclassOfClass:objc_getClass("QuickSpec")] )
                         [[objc_getClass("_TtC5Quick5World") sharedWorld]
                          setCurrentExampleMetadata:nil];
                 }
+
+            }
+            
+            if (testClasses.count){
+                if (!testQueue){
+                    testQueue = dispatch_queue_create("INTestQueue", NULL);
+                }
+                
+                dispatch_async(testQueue, ^{
+                    dispatch_suspend(testQueue);
+                    NSTimer *timer = [NSTimer timerWithTimeInterval:0 repeats:NO block:^(NSTimer * _Nonnull timer) {
+                        for (Class newClass in testClasses) {
+                            id suite0 = [[objc_getClass("XCTestSuite") alloc] initWithName:@"Injected"];
+                            id suite = [objc_getClass("XCTestSuite") testSuiteForTestCaseClass:newClass];
+                            id tr = [objc_getClass("XCTestSuiteRun") testRunWithTest:suite];
+                            [suite0 addTest:suite];
+                            [suite0 performTest:tr];
+                        }
+                        dispatch_resume(testQueue);
+                    }];
+                    [[NSRunLoop mainRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
+                });
             }
 
             [self fixClassRefs:hook];


### PR DESCRIPTION
Currently, main GCD queue is blocked during tests what makes
different context than standard XCTestCase.

Includes also minor bugfixing for unit testing python script:
* Allow white characters in product name
* Includes framework path taken from unit tests into linking